### PR TITLE
Refine balance types

### DIFF
--- a/neso/src/v1/api/balance.tsx
+++ b/neso/src/v1/api/balance.tsx
@@ -1,0 +1,14 @@
+import { topup } from '../balance/topup'
+
+app.post('/topup', async (ctx: app.Ctx, req: app.Req) => {
+  const { uid, email, did, dnum, currency, value } = req.body
+  const record = await topup(ctx, {
+    uid: Number(uid),
+    email,
+    did: Number(did),
+    dnum: Number(dnum),
+    currency,
+    value: Number(value),
+  })
+  return record
+})

--- a/neso/src/v1/balance/topup.tsx
+++ b/neso/src/v1/balance/topup.tsx
@@ -1,0 +1,15 @@
+import { Balance } from '../db/balance'
+import { TopupInput } from '../types/balance'
+
+export async function topup(ctx: app.Ctx, data: TopupInput) {
+  const record = await Balance.create(ctx, {
+    uid: data.uid,
+    email: data.email,
+    did: data.did,
+    dnum: data.dnum,
+    direction: 'topup',
+    currency: data.currency,
+    value: data.value,
+  })
+  return record
+}

--- a/neso/src/v1/db/balance.tsx
+++ b/neso/src/v1/db/balance.tsx
@@ -1,0 +1,12 @@
+import { Heap } from '@app/heap'
+
+export const Balance = Heap.Table('balance', {
+  id: Heap.Number(),
+  uid: Heap.Number(),
+  email: Heap.String(),
+  did: Heap.Number(),
+  dnum: Heap.Number(),
+  direction: Heap.String(),
+  currency: Heap.String(),
+  value: Heap.Number(),
+})

--- a/neso/src/v1/types/balance.tsx
+++ b/neso/src/v1/types/balance.tsx
@@ -1,0 +1,19 @@
+export interface BalanceRecord {
+  id: number
+  uid: number
+  email: string
+  did: number
+  dnum: number
+  direction: string
+  currency: string
+  value: number
+}
+
+export interface TopupInput {
+  uid: number
+  email: string
+  did: number
+  dnum: number
+  currency: string
+  value: number
+}


### PR DESCRIPTION
## Summary
- refine balance table with numeric ids
- update topup logic to use typed numeric IDs
- parse numeric fields in balance API
- define BalanceRecord and TopupInput types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68459d05276c8331bd4e5642cc10ffc1